### PR TITLE
use tmpdir task instead of default variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,7 @@ are shown below):
 
 ```yaml
 # Minikube version number
-minikube_version: '1.9.2'
-
-# Directory to store files downloaded for Minikube
-minikube_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
-```
+minikube_version: '1.9.2'```
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,3 @@
 ---
 # Minikube version number
 minikube_version: '1.9.2'
-
-# Directory to store files downloaded for Minikube
-minikube_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,33 +1,39 @@
 ---
-- name: create download directory
-  file:
+
+- name: minikube | create local temporary directory
+  tempfile:
     state: directory
-    mode: 'u=rwx,go=rx'
-    dest: '{{ minikube_download_dir }}'
+    suffix: binary
+  changed_when: false
+  delegate_to: 127.0.0.1
+  register: minikubeDownloadDirectory
 
 - name: download sha256sum
   get_url:
     url: '{{ minikube_mirror }}/{{ minikube_redis_filename }}.sha256'
-    dest: '{{ minikube_download_dir }}/{{ minikube_download_filename }}.sha256'
+    dest: '{{ minikubeDownloadDirectory.path }}/{{ minikube_download_filename }}.sha256'
     force: no
     use_proxy: yes
     validate_certs: yes
     mode: 'u=rw,go=r'
+  delegate_to: 127.0.0.1
 
 - name: read sha256sum
   slurp:
-    src: '{{ minikube_download_dir }}/{{ minikube_download_filename }}.sha256'
+    src: '{{ minikubeDownloadDirectory.path }}/{{ minikube_download_filename }}.sha256'
   register: minikube_sha256sum
+  delegate_to: 127.0.0.1
 
 - name: download Minikube
   get_url:
     url: '{{ minikube_mirror }}/{{ minikube_redis_filename }}'
-    dest: '{{ minikube_download_dir }}/{{ minikube_download_filename }}'
+    dest: '{{ minikubeDownloadDirectory.path }}/{{ minikube_download_filename }}'
     sha256sum: '{{ minikube_sha256sum.content | b64decode | trim }}'
     force: no
     use_proxy: yes
     validate_certs: yes
     mode: 'u=rw,go=r'
+  delegate_to: 127.0.0.1
 
 - name: create the Minikube installation dir
   become: yes
@@ -41,8 +47,7 @@
 - name: install Minikube
   become: yes
   copy:
-    src: '{{ minikube_download_dir }}/{{ minikube_download_filename }}'
-    remote_src: yes
+    src: '{{ minikubeDownloadDirectory.path }}/{{ minikube_download_filename }}'
     dest: '{{ minikube_install_path }}'
     force: yes
     owner: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
     use_proxy: yes
     validate_certs: yes
     mode: 'u=rw,go=r'
+  changed_when: false
   delegate_to: 127.0.0.1
 
 - name: read sha256sum
@@ -33,6 +34,7 @@
     use_proxy: yes
     validate_certs: yes
     mode: 'u=rw,go=r'
+  changed_when: false
   delegate_to: 127.0.0.1
 
 - name: create the Minikube installation dir


### PR DESCRIPTION
Using ansible built in tasks is always better :-).

Also, I find better to download the binary locally, then push it to production: deployment machines are most of the time in DMZ while 'production servers' out of the network.

PS: if you want also to start it, you can improve your deployment with the code of my wrapper role which I implements on top of your: https://github.com/OsgiliathEnterprise/ansible-orchestration

