### PR TITLE
Increased upper Debian test version to Bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Requirements
 
             * Buster (10)
             * Bullseye (11)
+            * Bookworm (12)
 
         * Ubuntu
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+        - bookworm
     - name: opensuse
       versions:
         - '15.4'

--- a/molecule/debian_max/molecule.yml
+++ b/molecule/debian_max/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible_role_minikube_debian_max
-    image: debian:11
+    image: debian:12
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Bookworm is the latest stable version of Debian.